### PR TITLE
suppressStyle function is missing a isset() check and causes PHP warning

### DIFF
--- a/src/Scripts/ProcessProperties.php
+++ b/src/Scripts/ProcessProperties.php
@@ -184,7 +184,7 @@ class ProcessProperties {
 		$j = false;
 		$i = 0;
 		while($j == false){
-			if($html[($nb+$i)]==">"){
+			if(isset($html[($nb+$i)]) && $html[($nb+$i)]==">"){
 				$j = true;
 			}
 			else{


### PR DESCRIPTION
Adding isset() check in side suppressStyle function will stop it from putting out PHP Warnings.