### PR TITLE
Enhance space processing in _processSpaces method

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ This is the very first version. I coded this because i wanted to put text from a
 INSTALLATION
 ============
 
-`composer require rkorebrits/htmltoopenxml`
+`composer require xjuvi/htmltoopenxml`
 
 WHAT H2OXML CAN DO
 ==================

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-  "name": "rkorebrits/htmltoopenxml",
+  "name": "xjuvi/htmltoopenxml",
   "license": "LGPL-3.0",
   "description": "Convert HTML to OpenOfficeXML",
   "keywords": [

--- a/src/Parser.php
+++ b/src/Parser.php
@@ -216,6 +216,16 @@ class Parser
 
     private function _processSpaces() {
         $this->_openXml = preg_replace("/(&nbsp;)/mi", " ", $this->_openXml);
+        $this->_openXml = preg_replace_callback(
+            '/<w:t.*?>(.*?)<\/w:t>/s',
+            function ($matches) {
+                $text = $matches[1];
+                /* Only remove leading and trailing spaces if they are not intentional. */
+                $text = preg_replace('/^\s+/', '', $text); // führende entfernen
+                return "<w:t>{$text}</w:t>";
+            },
+            $this->_openXml
+        );
         $this->_openXml = preg_replace("/(<w:t>)/mi", "<w:t xml:space='preserve'>", $this->_openXml);
 
         $this->_openXml = $this->minifyHtml($this->_openXml);


### PR DESCRIPTION
Add a callback to process leading and trailing spaces in text nodes.

**Before:**
<img width="55" height="201" alt="image" src="https://github.com/user-attachments/assets/f8598926-86b2-4349-b273-638918fc723c" />

**After:**
<img width="46" height="193" alt="image" src="https://github.com/user-attachments/assets/71f20892-0259-4c7a-9ea3-443315f6e213" />
